### PR TITLE
Fix the dependency on mariadb so the chart installs correctly

### DIFF
--- a/bugzilla/Chart.lock
+++ b/bugzilla/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: mariadb
+  repository: https://charts.bitnami.com/bitnami
+  version: 7.3.16
+digest: sha256:fa4a0c4b616470790642bdcd221140b61d71cb157ec94f22593ab4bad73f8352
+generated: "2020-03-27T03:21:01.055607-04:00"

--- a/bugzilla/Chart.yaml
+++ b/bugzilla/Chart.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: v2
 name: bugzilla
 description: Bugzilla bug tracking system
 version: 1.0.2
@@ -15,3 +15,10 @@ maintainers:
   - name: MoJaB
     email: hello@mojab.org
 engine: gotpl
+dependencies:
+  - name: mariadb
+    version: 7.x.x
+    repository: https://charts.bitnami.com/bitnami
+    condition: mariadb.enabled
+    tags:
+      - database

--- a/bugzilla/templates/_helpers.tpl
+++ b/bugzilla/templates/_helpers.tpl
@@ -51,3 +51,11 @@ app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "mariadb.fullname" -}}
+{{- printf "%s-%s" .Release.Name "mariadb" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/bugzilla/templates/deployment.yaml
+++ b/bugzilla/templates/deployment.yaml
@@ -58,7 +58,10 @@ spec:
             {{- end }}
             - name: DB_PASSWORD
             {{- if .Values.mariadb.enabled }}
-              value: {{ .Values.mariadb.db.password | quote }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "mariadb.fullname" . }}
+                  key: mariadb-password
             {{- else }}
               value: {{ .Values.externalDatabase.password | quote }}
             {{- end }}


### PR DESCRIPTION
Without having a helper for mariadb.fullname, the template was
not evaluating correctly.